### PR TITLE
now accepts single tsv input of multiple docs

### DIFF
--- a/oger/doc/__init__.py
+++ b/oger/doc/__init__.py
@@ -28,6 +28,7 @@ LOADERS = {
     'txt': TXTLoader,
     'txt_json': TXTJSONLoader,
     'txt.tar': TXTTarLoader,
+    'txt_tsv': TXTTSVLoader,
     'bioc': BioCXMLLoader,  # keep for backwards compatibility
     'bioc_xml': BioCXMLLoader,
     'bioc_json': BioCJSONLoader,

--- a/oger/doc/txt.py
+++ b/oger/doc/txt.py
@@ -9,7 +9,7 @@ Loader for plain-text input.
 '''
 
 
-__all__ = ['TXTLoader', 'TXTJSONLoader', 'TXTTarLoader']
+__all__ = ['TXTLoader', 'TXTJSONLoader', 'TXTTarLoader', 'TXTTSVLoader']
 
 
 import io
@@ -141,3 +141,17 @@ class TXTTarLoader(DocIterator, _TXTLoaderMixin):
                     continue  # member is not a regular file
                 id_ = basename(member.name)
                 yield self._document(stream, id_)
+
+
+class TXTTSVLoader(DocIterator, _TXTLoaderMixin):
+    '''
+    Loader for single TSV document consisting of 
+    ColumnA -> [id]
+    ColumnB -> [text] format
+    '''
+    def iter_documents(self, source):
+        with open(source, 'r') as f:
+            data = csv.reader(f, dialect='excel', delimiter='\t')
+            next(data) # skips header row
+            for idx, row in data:
+                yield self._document(row, idx)

--- a/oger/doc/txt.py
+++ b/oger/doc/txt.py
@@ -14,6 +14,7 @@ __all__ = ['TXTLoader', 'TXTJSONLoader', 'TXTTarLoader', 'TXTTSVLoader']
 
 import io
 import json
+import csv
 import tarfile
 
 from .document import Article

--- a/oger/test/tester.py
+++ b/oger/test/tester.py
@@ -61,6 +61,7 @@ TESTCASES = [
     'txt_collection',
     'txt_json',
     'txt_tar',
+    'txt_tsv',
     'conll',
     'pubtator',
     'pubtator_fbk',
@@ -269,6 +270,16 @@ def txt_collection(outputdir):
 
     # TODO output is just called 'None'
     # Is there a way to make that nicer?
+
+def txt_tsv(outputdir):
+    for output_format in OUTPUT_FORMATS:
+        testlogger.info('-> %s', output_format)
+        output = join(outdir(outputdir), output_format)
+        arguments = make_arguments(format='txt_tsv',
+                                   output=output,
+                                   export=output_format,
+                                   pointers='*.tsv')
+        run_with_arguments(arguments)
 
 def txt_json(outputdir):
     _multiple_outfmts(outdir(outputdir), 'txt_json')

--- a/oger/test/testfiles/txt_tsv/test.tsv
+++ b/oger/test/testfiles/txt_tsv/test.tsv
@@ -1,0 +1,11 @@
+tax_id	carbon_substrates
+442870	"alanine, alanine, glucose, serine, threonine"
+291968	"dextrin, fructose, glucose, glutamate, maltose, mannose, sucrose"
+258515	"arabinose, cellobiose, fructose, galactose, glucose, maltose, raffinose, salicin, sucrose, xylose"
+483199	xylose
+431306	glycerol
+285268	"arabinose, fructose, galactose, mannitol, sorbitol, sucrose, xylose"
+304077	glucose
+446692	"ethanol, glycerol"
+187327	"acetate, arginine, butanol, glycine, histidine, lactate, leucine, propionate"
+946336	"arabinose, cellobiose, fructose, galactose, glucose, lactose, maltose, mannose, melibiose, N-acetylgulcosamine, raffinose, rhamnose, ribose, salicin, sucrose, trehalose, xylose"


### PR DESCRIPTION
Very little code added to make this feature available. Built it over the existing `TXTLoader`. Added a test file too and the test passes successfully. Addresses issue #1 